### PR TITLE
Feature/cloud 1479 docker push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,18 @@ RUN apt-get update &&\
   rm -rf matching cache rm /var/lib/apt/lists/*
 
 # dockerfile_lint - ignore
+RUN rm -rf /var/lib/apt/lists/* &&\
+  \
+  curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip &&\
+  unzip awscliv2.zip &&\
+  aws/install &&\
+  rm -rf \
+  awscliv2.zip \
+  aws &&\
+  rm -rf /var/cache/apt/* &&\
+  aws --version
+
+# dockerfile_lint - ignore
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
   echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.0.0"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.0.1"
 


### PR DESCRIPTION
# Description
This ticket is only to verify all functionality in actions-cpp work with pushing to ECR repository. The current build noted in testing will fail due to incorrect arguments for `docker build`. However, this confirms that we are able to get to [publish.sh](https://github.com/variant-inc/actions-cpp/blob/master/entrypoint.sh#L99).

The story was overpointed. It only needed `aws cli` installed in Docker.
Fixes [#1479](https://drivevariant.atlassian.net/browse/CLOUD-1479)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)


## How Has This Been Tested?

It fails due to their DockerFile expected `ARGS` we don't provide or incorrect `ARGS`  name, but it passes everything up until `publish.sh`. So because of this, we will not be able to see `prime/app` image. 
```
ARG GCC_VERSION
ARG CMAKE_VERSION
ARG VARIANT_CONAN_REMOTE_URL
ARG VARIANT_CONAN_REMOTE_USER
ARG VARIANT_CONAN_REMOTE_PSWD
```

Build: https://github.com/variant-inc/prime/runs/5068816873?check_suite_focus=true#step:5:11159

- [x] Sanity Testing
```yaml
Test Steps:
1. On this prime branch https://github.com/variant-inc/prime/tree/feature/actions-cpp, create a dummy commit
2. See that the build is able to reach eval "docker build $BUILD_ARGS -t $IMAGE $DOCKERFILE_PATH" in publish.sh
Results: [INSERT RESULTS HERE]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
