### PR TITLE
Feature/cloud 1476 sonar fail logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.0.1"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.0.2"
 

--- a/scripts/coverage_scan.sh
+++ b/scripts/coverage_scan.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
+sonar_logout() {
+  exit_code=$?
+  echo "Exit code is $exit_code"
+  if [ "$exit_code" -eq 0 ]; then
+    echo -e "\e[1;32m ________________________________________________________________\e[0m"
+    echo -e "\e[1;32m Quality Gate Passed.\e[0m"
+    echo -e "\e[1;32m ________________________________________________________________\e[0m"
+  elif [ "$exit_code" -gt 0 ]; then
+    set -e
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m Sonar Quality Gate failed in $SONAR_PROJECT_KEY.\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    exit 1 
+  fi
+}
+
 echo "===Cmake Coverage==="
 cd build
 cmake -G"Unix Makefiles" -DCODE_COVERAGE=ON ..
@@ -24,6 +46,7 @@ sonar_args="-Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.cfamily.cache.enabled=false \
             -Dsonar.qualitygate.wait=$wait_flag"
 
+trap "sonar_logout" EXIT
 
 if [ "$PULL_REQUEST_KEY" = null ]; then
   echo "Sonar run when pull request key is null."


### PR DESCRIPTION
# Description

Added sonar logs.
Image tag will change from `v1.0.1` -> `v1.0.2`
Fixes [#1476](https://drivevariant.atlassian.net/browse/CLOUD-1476)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

[Sonar Link](https://sonarcloud.io/organizations/variant/quality_gates/show/56084)
[Mirage Main](https://github.com/variant-inc/mirage/tree/main)

- [x] Sanity Testing
```yaml
Test Case 1: Sonar Pass
  1.  Checkout "main" branch from mirage
  2. Push Dummy commit
Result
  - Expected: See Sonar Pass with pretty green logs "Quality Gate Passed".
  - https://github.com/variant-inc/mirage/runs/5236584311?check_suite_focus=true#step:5:5797
  - Actual: [INSERT HERE}


Test Case 2: Sonar Fail
  1. Checkout "main" branch from mirage
  2. Comment out any .cpp file
  3. Push Dummy commit
Result
  - Expected: See Sonar Fail with pretty red logs "Sonar Quality Gate failed in $SONAR_PROJECT_KEY". 
  - https://github.com/variant-inc/mirage/runs/5236583051?check_suite_focus=true#step:5:5418
  - Actual: [INSERT HERE]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
