### PR TITLE
Feature/cloud 1738 enable and skip sonar

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -30,7 +30,7 @@ jobs:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
-          docker buildx build \
+          docker build \
             --build-arg BUILD_DATE \
             --build-arg BUILD_REVISION=$GITHUB_SHA \
             --build-arg BUILD_VERSION=$GITHUB_SHA \

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,15 @@ RUN python3 -m pip install --upgrade pip; \
     pip3 install conan; \
     pip3 install conan_package_tools;
 
+#install powershell
+RUN curl -sLo "packages-microsoft-prod.deb" https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb &&\
+  dpkg -i packages-microsoft-prod.deb &&\
+  apt-get update &&\
+  apt-get install -y --no-install-recommends \
+  powershell &&\
+  rm -rf /var/lib/apt/lists/* &&\
+  pwsh -v;
+
 COPY . /
 
 RUN CONFIG_GCOV_KERNEL=y; \

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.0.2"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:test-latest"
 

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:test-latest"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.1.0"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ cd "$GITHUB_WORKSPACE"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b feature/CLOUD-1738-skip-sonar-analysis https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -92,7 +92,7 @@ if [ "$skip_sonar_run" != 'True' ]; then
   sh -c "/scripts/coverage_scan.sh"
   echo "End: Coverage Scan"
 else
-  echo "End: Skipping sonar run"
+  echo "Skipping sonar run"
 fi
 
 echo "Conan Push: $INPUT_CONAN_PUSH_ENABLED"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ cd "$GITHUB_WORKSPACE"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b feature/CLOUD-1738-skip-sonar-analysis https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -78,9 +78,22 @@ echo "Start: Conan"
 sh -c "/scripts/conan.sh"
 echo "End: Conan"
 
-echo "Start: Coverage Scan"
-sh -c "/scripts/coverage_scan.sh"
-echo "End: Coverage Scan"
+echo "Start: Enable sonar"
+pwsh ./actions-collection/scripts/enable_sonar.ps1
+echo "End: Enable sonar"
+
+echo "Start: Check sonar run"
+skip_sonar_run=$(pwsh ./actions-collection/scripts/skip_sonar_run.ps1)
+echo "Skip sonar run: $skip_sonar_run"
+echo "End: Check sonar run"
+
+if [ "$skip_sonar_run" != 'True' ]; then
+  echo "Start: Coverage Scan"
+  sh -c "/scripts/coverage_scan.sh"
+  echo "End: Coverage Scan"
+else
+  echo "End: Skipping sonar run"
+fi
 
 echo "Conan Push: $INPUT_CONAN_PUSH_ENABLED"
 if [ "$INPUT_CONAN_PUSH_ENABLED" = 'true' ]; then


### PR DESCRIPTION
# Description

Skip sonar run in case of re-run.

Fixes [#6](https://usxtech.atlassian.net/browse/CLOUD-1738)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

[Mirage](https://github.com/variant-inc/mirage/tree/test/enable-skip-sonar)

```yaml
Test Case 1: Sonar Should run
  1. Navigate to demo app branch create a commit.
  2. Should trigger sonar run. Also verify in sonar if results are pushed.

Result
  - Expected: See sonar is run on the commit.
  - Actual: 

Test Case 2: Skip sonar run
  1. Navigate to actions and pick the run previously created.
  2. Re-run the build, it should trigger sonar run as sonar has already been run on this commit.

Result
  - Expected: See sonar is skipped, lazy action step logs should say sonar is skipped.
```

- [ ] Unit Tests
- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
