### PR TITLE
F/cloud 1740 skip image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.1.0"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:test-latest"
 

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:test-latest"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/cpp-action:v1.1.1"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ cd "$GITHUB_WORKSPACE"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,7 +109,7 @@ if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
   echo "End: Checking ECR Repo"
   echo "Start: Publish Image to ECR"
-  ./actions-collection/scripts/publish.sh
+  pwsh ./actions-collection/scripts/publish.ps1
   echo "End: Publish Image to ECR"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ cd "$GITHUB_WORKSPACE"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh


### PR DESCRIPTION
# Description

Skip ecr image if it is already generated.

Fixes [#7](https://usxtech.atlassian.net/browse/CLOUD-1740)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

[Prime app](https://github.com/variant-inc/prime/tree/test/skip-ecr-push)

```yaml
Test Case 1: ECR image should be pushed and existing flow should remain same
  1. Navigate to demo app branch create a commit.
  2. Should trigger run and existing flow should remain same and push image to ECR
  3. Look for log "New image, proceeding to docker push"

Result
  - Expected: See image is pushed with that commit.
  - Actual: 

Test Case 2: Skip image push when re-run
  1. Navigate to actions and pick the run previously created.
  2. Re-run the build, it should trigger the run and should not push image to ECR.
  4. Look for log "Image already pushed. Skipping docker push"

Result
  - Expected: ECR image push should be skipped.
```

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
